### PR TITLE
Update iOS SDK version requirements to versions between 1.7.10 and 1.8.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
             <source url="https://github.com/CocoaPods/Specs.git"/>
          </config>
          <pods use-frameworks="true">
-            <pod name="Smartlook" spec=">= 1.5.0"/>
+            <pod name="Smartlook" spec="~> 1.7.10"/>
          </pods>
       </podspec>   
     </platform>


### PR DESCRIPTION
Specifies the required native iOS SDK version to `>= 1.7.10` and lesser that the next minor version `1.8`.

Please add to the nearest Cordova release, should be out before iOS SDK 1.8 is released sometime middle September.